### PR TITLE
convert ProblemSize to Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ let population_size = 2_i32.pow(log2 as u32) as usize;
 
 let (solutions, generation, progress) = GeneticExecution::<u8, QueensBoard>::new()
     .population_size(population_size)
-    .genotype_size(n_queens as u8)
+    .environment(n_queens as u8)
     .mutation_rate(Box::new(MutationRates::Linear(SlopeParams {
         start: f64::from(n_queens) / (8_f64 + 2_f64 * log2) / 100_f64,
         bound: 0.005,
@@ -127,7 +127,7 @@ let population_size = 2_i32.pow(log2 as u32) as usize;
 
 let (_solutions, _generation, _progress, population) = GeneticExecution::<u8, QueensBoard>::new()
     .population_size(population_size)
-    .genotype_size(n_queens as u8)
+    .environment(n_queens as u8)
     .mutation_rate(Box::new(MutationRates::Linear(SlopeParams {
         start: f64::from(n_queens) / (8_f64 + 2_f64 * log2) / 100_f64,
         bound: 0.005,
@@ -148,7 +148,7 @@ let (_solutions, _generation, _progress, population) = GeneticExecution::<u8, Qu
 
 let (solutions, generation, progress, _population) = GeneticExecution::<u8, QueensBoard>::new()
     .population_size(population_size)
-    .genotype_size(n_queens as u8)
+    .environment(n_queens as u8)
     .mutation_rate(Box::new(MutationRates::Linear(SlopeParams {
         start: f64::from(n_queens) / (8_f64 + 4_f64 * log2) / 100_f64,
         bound: 0.005,

--- a/fd-oxigen/src/main.rs
+++ b/fd-oxigen/src/main.rs
@@ -289,7 +289,7 @@ impl<'a> FdParams<'a> {
 impl<'a> Genotype<u8> for FdParams<'a> {
     // The path to the fast-downard.py and the folder with domains and problems
     // A instance of a default hasher is used too to hash the genes as SAS filenames.
-    type ProblemSize = &'a [&'a str];
+    type Environment = &'a [&'a str];
     type GenotypeHash = Self;
 
     fn iter(&self) -> std::slice::Iter<u8> {
@@ -302,7 +302,7 @@ impl<'a> Genotype<u8> for FdParams<'a> {
         self.genes = genes.collect();
     }
 
-    fn generate(size: &Self::ProblemSize) -> Self {
+    fn generate(size: &Self::Environment) -> Self {
         let mut individual = Vec::with_capacity(8 as usize);
         let mut rgen = SmallRng::from_entropy();
         for i in 0..11 {
@@ -414,7 +414,7 @@ fn main() {
 
     let (_solutions, generation, progress, _population) = GeneticExecution::<u8, FdParams>::new()
         .population_size(population_size)
-        .genotype_size(&fd_params)
+        .environment(&fd_params)
         .mutation_rate(Box::new(MutationRates::Linear(SlopeParams {
             start: 0.05,
             bound: 0.005,

--- a/knapsack-oxigen/src/main.rs
+++ b/knapsack-oxigen/src/main.rs
@@ -50,7 +50,7 @@ impl<'a> Debug for Knapsack<'a> {
 }
 
 impl<'a> Genotype<bool> for Knapsack<'a> {
-    type ProblemSize = (f64, &'a [Item]);
+    type Environment = (f64, &'a [Item]);
 
     fn iter(&self) -> std::slice::Iter<bool> {
         self.items.iter()
@@ -62,7 +62,7 @@ impl<'a> Genotype<bool> for Knapsack<'a> {
         self.items = genes.collect();
     }
 
-    fn generate(size: &Self::ProblemSize) -> Self {
+    fn generate(size: &Self::Environment) -> Self {
         let mut individual = Knapsack {
             capacity: size.0,
             items: Vec::with_capacity(size.1.len()),
@@ -188,7 +188,7 @@ fn main() {
     }
     let (solutions, generation, progress, _population) = GeneticExecution::<bool, Knapsack>::new()
         .population_size(population_size)
-        .genotype_size((capacity, &items))
+        .environment((capacity, &items))
         .mutation_rate(Box::new(MutationRates::Linear(SlopeParams {
             start: 15.0,
             bound: 0.005,

--- a/nqueens-oxigen/src/main.rs
+++ b/nqueens-oxigen/src/main.rs
@@ -29,7 +29,7 @@ impl Display for QueensBoard {
 }
 
 impl Genotype<u8> for QueensBoard {
-    type ProblemSize = u8;
+    type Environment = u8;
     type GenotypeHash = Self;
 
     fn iter(&self) -> std::slice::Iter<u8> {
@@ -42,7 +42,7 @@ impl Genotype<u8> for QueensBoard {
         self.0 = genes.collect();
     }
 
-    fn generate(size: &Self::ProblemSize) -> Self {
+    fn generate(size: &Self::Environment) -> Self {
         let mut individual = Vec::with_capacity(*size as usize);
         let mut rgen = SmallRng::from_entropy();
         for _i in 0..*size {
@@ -131,7 +131,7 @@ fn main() {
 
     let (solutions, generation, progress, _population) = GeneticExecution::<u8, QueensBoard>::new()
         .population_size(population_size)
-        .genotype_size(n_queens as u8)
+        .environment(n_queens as u8)
         .mutation_rate(Box::new(MutationRates::Linear(SlopeParams {
             start: f64::from(n_queens) / (2_f64 + 4_f64 * log2) / 100_f64,
             bound: 0.0005,

--- a/onemax-oxigen/src/main.rs
+++ b/onemax-oxigen/src/main.rs
@@ -17,7 +17,7 @@ impl Display for OneMax {
 }
 
 impl Genotype<bool> for OneMax {
-    type ProblemSize = usize;
+    type Environment = usize;
 
     fn iter(&self) -> std::slice::Iter<bool> {
         self.0.iter()
@@ -29,7 +29,7 @@ impl Genotype<bool> for OneMax {
         self.0 = genes.collect();
     }
 
-    fn generate(size: &Self::ProblemSize) -> Self {
+    fn generate(size: &Self::Environment) -> Self {
         let mut individual = Vec::with_capacity(*size as usize);
         let mut rgen = SmallRng::from_entropy();
         for _i in 0..*size {
@@ -61,7 +61,7 @@ fn main() {
     let log2 = (f64::from(problem_size as u32) * 4_f64).log2().ceil();
     let (solutions, generation, _progress, _population) = GeneticExecution::<bool, OneMax>::new()
         .population_size(population_size)
-        .genotype_size(problem_size)
+        .environment(problem_size)
         .mutation_rate(Box::new(MutationRates::Linear(SlopeParams {
             start: f64::from(problem_size as u32) / (8_f64 + 2_f64 * log2) / 100_f64,
             bound: 0.005,

--- a/oxigen/src/benchmarks.rs
+++ b/oxigen/src/benchmarks.rs
@@ -42,7 +42,7 @@ impl FromIterator<u8> for QueensBoard {
 }
 
 impl Genotype<u8> for QueensBoard {
-    type ProblemSize = u8;
+    type Environment = u8;
     #[cfg(feature = "global_cache")]
     type GenotypeHash = Self;
 
@@ -56,7 +56,7 @@ impl Genotype<u8> for QueensBoard {
         self.0 = genes.collect();
     }
 
-    fn generate(size: &Self::ProblemSize) -> Self {
+    fn generate(size: &Self::Environment) -> Self {
         let mut individual = Vec::with_capacity(*size as usize);
         let mut rgen = SmallRng::from_entropy();
         for _i in 0..*size {
@@ -135,7 +135,7 @@ fn bench_mutation_1024inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8),
+            .environment(n_queens as u8),
     );
     b.iter(|| {
         gen_exec.mutate(mutation_rate);
@@ -150,13 +150,13 @@ fn bench_selection_cup_255inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .select_function(Box::new(SelectionFunctions::Cup)),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -175,7 +175,7 @@ fn bench_selection_tournaments_256inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .select_function(Box::new(SelectionFunctions::Tournaments(NTournaments(
                 population_size / 4,
             )))),
@@ -183,7 +183,7 @@ fn bench_selection_tournaments_256inds(b: &mut Bencher) {
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -204,13 +204,13 @@ fn bench_selection_roulette_256inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .select_function(Box::new(SelectionFunctions::Roulette)),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -231,13 +231,13 @@ fn bench_cross_single_point_255inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .crossover_function(Box::new(CrossoverFunctions::SingleCrossPoint)),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -257,13 +257,13 @@ fn bench_cross_multi_point_255inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .crossover_function(Box::new(CrossoverFunctions::MultiCrossPoint)),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -283,13 +283,13 @@ fn bench_cross_uniform_255inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .crossover_function(Box::new(CrossoverFunctions::UniformCross)),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -309,13 +309,13 @@ fn bench_fitness_not_cached_1024inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .cache_fitness(false),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -332,13 +332,13 @@ fn bench_fitness_1024inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .global_cache(false),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -359,12 +359,12 @@ fn bench_fitness_global_cache_1024inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8),
+            .environment(n_queens as u8),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -384,7 +384,7 @@ fn bench_fitness_age_not_cached_1024inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .age_function(Box::new(AgeFunctions::Quadratic(
                 AgeThreshold(0),
                 AgeSlope(1_f64),
@@ -394,7 +394,7 @@ fn bench_fitness_age_not_cached_1024inds(b: &mut Bencher) {
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -413,7 +413,7 @@ fn bench_fitness_age_1024inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .global_cache(false)
             .age_function(Box::new(AgeFunctions::Quadratic(
                 AgeThreshold(0),
@@ -423,7 +423,7 @@ fn bench_fitness_age_1024inds(b: &mut Bencher) {
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -442,12 +442,12 @@ fn bench_get_fitnesses_1024inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8),
+            .environment(n_queens as u8),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -465,12 +465,12 @@ fn bench_update_progress_1024inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8),
+            .environment(n_queens as u8),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -492,12 +492,12 @@ fn bench_get_solutions_1024inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8),
+            .environment(n_queens as u8),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -515,13 +515,13 @@ fn bench_survival_pressure_worst_255inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(SurvivalPressureFunctions::Worst)),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -573,7 +573,7 @@ fn bench_survival_pressure_children_replace_most_similar_255inds(b: &mut Bencher
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(
                 SurvivalPressureFunctions::ChildrenReplaceMostSimilar,
             )),
@@ -581,7 +581,7 @@ fn bench_survival_pressure_children_replace_most_similar_255inds(b: &mut Bencher
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -633,7 +633,7 @@ fn bench_survival_pressure_children_replace_parents_255inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(
                 SurvivalPressureFunctions::ChildrenReplaceParents,
             )),
@@ -641,7 +641,7 @@ fn bench_survival_pressure_children_replace_parents_255inds(b: &mut Bencher) {
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -693,7 +693,7 @@ fn bench_survival_pressure_children_fight_most_similar_255inds(b: &mut Bencher) 
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(
                 SurvivalPressureFunctions::ChildrenFightMostSimilar,
             )),
@@ -701,7 +701,7 @@ fn bench_survival_pressure_children_fight_most_similar_255inds(b: &mut Bencher) 
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -753,13 +753,13 @@ fn bench_survival_pressure_children_fight_parents_255inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(SurvivalPressureFunctions::ChildrenFightParents)),
     );
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -811,7 +811,7 @@ fn bench_survival_pressure_overpopulation_255inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(SurvivalPressureFunctions::Overpopulation(
                 M::new(
                     population_size - population_size / 4,
@@ -823,7 +823,7 @@ fn bench_survival_pressure_overpopulation_255inds(b: &mut Bencher) {
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -875,7 +875,7 @@ fn bench_survival_pressure_competitive_overpopulation_255inds(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(
                 SurvivalPressureFunctions::CompetitiveOverpopulation(M::new(
                     population_size - population_size / 4,
@@ -887,7 +887,7 @@ fn bench_survival_pressure_competitive_overpopulation_255inds(b: &mut Bencher) {
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -939,7 +939,7 @@ fn bench_survival_pressure_deterministic_overpopulation_255inds(b: &mut Bencher)
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(
                 SurvivalPressureFunctions::DeterministicOverpopulation,
             )),
@@ -947,7 +947,7 @@ fn bench_survival_pressure_deterministic_overpopulation_255inds(b: &mut Bencher)
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -1001,7 +1001,7 @@ fn bench_survival_pressure_children_replace_parents_and_the_rest_random_most_sim
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(
                 SurvivalPressureFunctions::ChildrenReplaceParentsAndTheRestRandomMostSimilar,
             )),
@@ -1009,7 +1009,7 @@ fn bench_survival_pressure_children_replace_parents_and_the_rest_random_most_sim
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -1063,7 +1063,7 @@ fn bench_survival_pressure_children_replace_parents_and_the_rest_most_similar_25
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(
                 SurvivalPressureFunctions::ChildrenReplaceParentsAndTheRestMostSimilar,
             )),
@@ -1071,7 +1071,7 @@ fn bench_survival_pressure_children_replace_parents_and_the_rest_most_similar_25
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }
@@ -1123,14 +1123,14 @@ fn bench_distance_255(b: &mut Bencher) {
     let mut gen_exec = test::black_box(
         GeneticExecution::<u8, QueensBoard>::new()
             .population_size(population_size)
-            .genotype_size(n_queens as u8)
+            .environment(n_queens as u8)
             .survival_pressure_function(Box::new(SurvivalPressureFunctions::Worst)),
     );
     gen_exec.population = test::black_box(Vec::new());
     // Initialize randomly the population
     for _ind in 0..gen_exec.population_size {
         gen_exec.population.push(IndWithFitness::new(
-            QueensBoard::generate(&gen_exec.genotype_size),
+            QueensBoard::generate(&gen_exec.environment),
             None,
         ));
     }

--- a/oxigen/src/genotype.rs
+++ b/oxigen/src/genotype.rs
@@ -9,10 +9,10 @@ use std::vec::IntoIter;
 /// It defines the fitness and mutation functions and the type of the
 /// individual representation.
 pub trait Genotype<T: PartialEq>: Display + Clone + Send + Sync {
-    /// The type that represents the problem size of the genotype. For example,
-    /// in the N Queens problem the size of the `ProblemSize` is a numeric type
+    /// The type that represents the problem environment. For example,
+    /// in the N Queens problem the `Environment` is a numeric type
     /// (the number of queens).
-    type ProblemSize: Default + Send + Sync;
+    type Environment: Default + Send + Sync;
 
     /// The type that is used for hashing, by default the self struct.
     #[cfg(feature = "global_cache")]
@@ -28,7 +28,7 @@ pub trait Genotype<T: PartialEq>: Display + Clone + Send + Sync {
     fn from_iter<I: Iterator<Item = T>>(&mut self, I);
 
     /// Randomly initiailzes an individual.
-    fn generate(size: &Self::ProblemSize) -> Self;
+    fn generate(size: &Self::Environment) -> Self;
 
     /// Returns a fitness value for an individual.
     fn fitness(&self) -> f64;

--- a/oxigen/src/lib.rs
+++ b/oxigen/src/lib.rs
@@ -112,8 +112,8 @@ pub struct GeneticExecution<T: PartialEq + Send + Sync, Ind: Genotype<T>> {
     population_size: usize,
     /// Population with all individuals and their respective fitnesses.
     population: Vec<IndWithFitness<T, Ind>>,
-    /// Size of the genotype problem.
-    genotype_size: Ind::ProblemSize,
+    /// Environment associated with the problem.
+    environment: Ind::Environment,
     /// The mutation rate variation along iterations and progress.
     mutation_rate: Box<dyn MutationRate>,
     /// The number of stages in the cup whose individuals are selected to crossover.
@@ -151,7 +151,7 @@ impl<T: PartialEq + Send + Sync, Ind: Genotype<T>> Default for GeneticExecution<
         GeneticExecution {
             population_size: 64,
             population: Vec::new(),
-            genotype_size: Ind::ProblemSize::default(),
+            environment: Ind::Environment::default(),
             mutation_rate: Box::new(MutationRates::Constant(0.1)),
             selection_rate: Box::new(SelectionRates::Constant(2)),
             selection: Box::new(SelectionFunctions::Cup),
@@ -194,9 +194,9 @@ impl<T: PartialEq + Send + Sync, Ind: Genotype<T>> GeneticExecution<T, Ind> {
         self
     }
 
-    /// Sets the genotype size.
-    pub fn genotype_size(mut self, new_size: Ind::ProblemSize) -> Self {
-        self.genotype_size = new_size;
+    /// Sets the environment.
+    pub fn environment(mut self, env: Ind::Environment) -> Self {
+        self.environment = env;
         self
     }
 
@@ -307,7 +307,7 @@ impl<T: PartialEq + Send + Sync, Ind: Genotype<T>> GeneticExecution<T, Ind> {
         // Initialize randomly the population
         while self.population.len() < self.population_size {
             self.population.push(IndWithFitness::new(
-                Ind::generate(&self.genotype_size),
+                Ind::generate(&self.environment),
                 None,
             ));
         }


### PR DESCRIPTION
in reference to #9, this change re-brands the `ProblemSize` type to an `Environment` type to pass relevant, problem-specific information