### PR TITLE
Feature/partially matched uniform cx

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Oxigen provides the following features:
 * Customizable mutation and selection rates with constant, linear and Quadratic functions according to generations built-in (you can implement your own functions via the `MutationRate` and `SelectionRate` traits).
 * Customizable age unfitness of individuals, with no unfitness, linear and Quadratic unfitness with threshold according to generations of the individual built-in (you can implement your own age functions via the `Age` trait).
 * Accumulated `Roulette`, `Tournaments` and `Cup` built-in selection functions (you can implement your own selection functions via the `Selection` trait).
-* `SingleCrossPoint`, `MultiCrossPoint` and `UniformCross` built-in crossover functions (you can implement your own crossover function via the `Crossover` trait).
+* `SingleCrossPoint`, `MultiCrossPoint`, `UniformCross`, and `UniformPartiallyMatched` built-in crossover functions (you can implement your own crossover function via the `Crossover` trait).
 * Many built-in survival pressure functions. You can implement your own survival pressure functions via the `SurvivalPressure` trait.
 * `Niches` built-in `PopulationRefitness` function. You can implement your own population refitness functions via the `PopulationRefitness` trait.
 * `SolutionFound`, `Generation` and `Progress` and more built-in stop criteria (you can implement your own stop criteria via the `StopCriterion` trait).

--- a/oxigen/src/crossover.rs
+++ b/oxigen/src/crossover.rs
@@ -4,6 +4,8 @@ use genotype::Genotype;
 use rand::distributions::Uniform;
 use rand::prelude::*;
 use std::cmp::{min, PartialEq};
+use std::mem::replace;
+
 use CrossoverFunctions::*;
 
 /// This trait defines the cross function.
@@ -21,6 +23,8 @@ pub enum CrossoverFunctions {
     MultiCrossPoint,
     /// Uniform Crossover.
     UniformCross,
+    /// Uniform Partially Matched
+    UniformPartiallyMatched(f32)
 }
 
 impl<T: PartialEq, G: Genotype<T>> Crossover<T, G> for CrossoverFunctions {
@@ -126,6 +130,58 @@ impl<T: PartialEq, G: Genotype<T>> Crossover<T, G> for CrossoverFunctions {
                         .zip(ind2.clone().into_iter())
                         .enumerate()
                         .map(|(i, (gen1, gen2))| if i % 2 != 0 { gen1 } else { gen2 }),
+                );
+
+                (child1, child2)
+            }
+            UniformPartiallyMatched(indpb) => {
+                let size = min(ind1.iter().len(), ind2.iter().len());
+
+                let mut ind1_temp : Vec<Option<T>> = ind1.clone().into_iter().map(|e| Some(e)).collect();
+                let mut ind2_temp : Vec<Option<T>> = ind2.clone().into_iter().map(|e| Some(e)).collect();
+
+                let mut i1 : Vec<usize> = (0..ind1_temp.len()).collect();
+                let mut i2 : Vec<usize> = (0..ind2_temp.len()).collect();
+
+                let mut p1 = vec![0; size];
+                let mut p2 = vec![0; size];
+
+                for i in 0..size {
+                    p1[i1[i]] = i;
+                    p2[i2[i]] = i;
+                }
+
+                for i in 0..size {
+                    let p : f32 = SmallRng::from_entropy().gen();
+                    if p < *indpb {
+                        let temp1 = i1[i];
+                        let temp2 = i2[i];
+
+                        i1[i] = temp2;
+                        i1[p1[temp2]] = temp1;
+
+                        i2[i] = temp1;
+                        i2[p2[temp1]] = temp2;
+
+                        p1[temp1] = p1[temp2];
+                        p1[temp2] = p1[temp1];
+                        p2[temp1] = p2[temp2];
+                        p2[temp2] = p2[temp1];
+                    }
+                }
+
+                let mut child1 = ind1.clone();
+                child1.from_iter(
+                    i1.iter().map(|loc| {
+                        replace(&mut ind1_temp[*loc], None).unwrap()
+                    })
+                );
+
+                let mut child2 = ind2.clone();
+                child2.from_iter(
+                    i2.iter().map(|loc| {
+                        replace(&mut ind2_temp[*loc], None).unwrap()
+                    })
                 );
 
                 (child1, child2)


### PR DESCRIPTION
An implementation of "uniform partially matched crossover". An example is given in this [paper](https://arxiv.org/ftp/arxiv/papers/1203/1203.3097.pdf) in section 4.4.4. Useful for problems such as traveling salesman and genotypes that require uniquely-labeled genes `0` through `N` to remain present in the chromosome following crossover. An example of the problem having such a crossover alleviates:

Parent 1: `[1,2,3,4,5]`
Parent 2: `[5,4,3,2,1]`

_Single point crossover after the 2nd index_

Child 1: `[5,4,3,4,5]`
Child 2: `[1,2,3,2,1]`

If you imagine the genes as stops along a route, the resulting genotypes are no longer valid because 2 locations are skipped in each child representation. This is the problem that partially-matched crossover is meant to alleviate; it's an element-preserving operation.